### PR TITLE
UniVRM 0.80(Runtime import, export)対応

### DIFF
--- a/DVRSDK/Assets/DVRSDK/DVRAvatar/Scripts/VRMLoader.cs
+++ b/DVRSDK/Assets/DVRSDK/DVRAvatar/Scripts/VRMLoader.cs
@@ -3,10 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-#if UNIVRM_0_77_IMPORTER
-using UniGLTF;
-#endif
-#if UNIVRM_0_68_IMPORTER
+#if UNIVRM_0_68_IMPORTER || UNIVRM_0_77_IMPORTER
 using UniGLTF;
 #endif
 using UnityEngine;
@@ -16,13 +13,16 @@ namespace DVRSDK.Avatar
 {
     public class VRMLoader : IDisposable
     {
-#if UNIVRM_0_77_IMPORTER
+#if UNIVRM_LEGACY_IMPORTER || UNIVRM_0_68_IMPORTER
+        private VRMImporterContext currentContext;
+        public GameObject Model => currentContext == null ? null : currentContext.Root;
+#elif UNIVRM_0_77_IMPORTER
         private VRMImporterContext currentContext;
         private RuntimeGltfInstance currentInstance;
         public GameObject Model => currentInstance == null ? null : currentInstance.Root;
 #else
-        private VRMImporterContext currentContext;
-        public GameObject Model => currentContext == null ? null : currentContext.Root;
+        private IDisposable currentContext = null;
+        public GameObject Model = null;
 #endif
 
 
@@ -31,13 +31,16 @@ namespace DVRSDK.Avatar
         /// </summary>
         public void ShowMeshes()
         {
+#if UNIVRM_LEGACY_IMPORTER || UNIVRM_0_68_IMPORTER || UNIVRM_0_77_IMPORTER
             if (Model == null)
                 throw new InvalidOperationException("Need to load VRM model first.");
+#endif
 
-#if UNIVRM_0_77_IMPORTER
+#if UNIVRM_LEGACY_IMPORTER || UNIVRM_0_68_IMPORTER
+            currentContext.ShowMeshes();
+#elif UNIVRM_0_77_IMPORTER
             currentInstance.ShowMeshes();
 #else
-            currentContext.ShowMeshes();
 #endif
 
 #if UNIVRM_0_68_IMPORTER
@@ -287,9 +290,13 @@ namespace DVRSDK.Avatar
         /// <returns>VRMMetaObject</returns>
         public VRMMetaObject GetMeta(bool createThumbnail)
         {
+#if UNIVRM_LEGACY_IMPORTER || UNIVRM_0_68_IMPORTER || UNIVRM_0_77_IMPORTER
             if (currentContext == null)
                 throw new InvalidOperationException("Need to initialize VRM model first.");
             return currentContext.ReadMeta(createThumbnail);
+#else
+            return null;
+#endif
         }
 
         // Byte列を得る

--- a/DVRSDK/Assets/DVRSDK/Editor/PluginVersionChecker.cs
+++ b/DVRSDK/Assets/DVRSDK/Editor/PluginVersionChecker.cs
@@ -38,8 +38,9 @@ namespace DVRSDK.Editor
                 }
 
                 symbols.Remove("UNIVRM_0_68_IMPORTER");
+                symbols.Remove("UNIVRM_0_77_IMPORTER");
             }
-            else
+            else if (version.Value.major == 0 && version.Value.minor < 77)
             {
                 if (!symbols.Contains("UNIVRM_0_68_IMPORTER"))
                 {
@@ -47,6 +48,17 @@ namespace DVRSDK.Editor
                 }
 
                 symbols.Remove("UNIVRM_LEGACY_IMPORTER");
+                symbols.Remove("UNIVRM_0_77_IMPORTER");
+            }
+            else
+            {
+                if (!symbols.Contains("UNIVRM_0_77_IMPORTER"))
+                {
+                    symbols.Add("UNIVRM_0_77_IMPORTER");
+                }
+
+                symbols.Remove("UNIVRM_LEGACY_IMPORTER");
+                symbols.Remove("UNIVRM_0_68_IMPORTER");
             }
 
             // Exporter

--- a/DVRSDK/Assets/DVRSDK/Editor/PluginVersionChecker.cs
+++ b/DVRSDK/Assets/DVRSDK/Editor/PluginVersionChecker.cs
@@ -30,55 +30,42 @@ namespace DVRSDK.Editor
             var version = GetVRMVersion();
 
             // Importer
+            symbols.Remove("UNIVRM_0_68_IMPORTER");
+            symbols.Remove("UNIVRM_0_77_IMPORTER");
+            symbols.Remove("UNIVRM_LEGACY_IMPORTER");
             if (version.Value.major == 0 && version.Value.minor < 68)
             {
-                if (!symbols.Contains("UNIVRM_LEGACY_IMPORTER"))
-                {
-                    symbols.Add("UNIVRM_LEGACY_IMPORTER");
-                }
-
-                symbols.Remove("UNIVRM_0_68_IMPORTER");
-                symbols.Remove("UNIVRM_0_77_IMPORTER");
+                symbols.Add("UNIVRM_LEGACY_IMPORTER");
             }
             else if (version.Value.major == 0 && version.Value.minor < 77)
             {
-                if (!symbols.Contains("UNIVRM_0_68_IMPORTER"))
-                {
-                    symbols.Add("UNIVRM_0_68_IMPORTER");
-                }
-
-                symbols.Remove("UNIVRM_LEGACY_IMPORTER");
-                symbols.Remove("UNIVRM_0_77_IMPORTER");
+                symbols.Add("UNIVRM_0_68_IMPORTER");
             }
             else
             {
-                if (!symbols.Contains("UNIVRM_0_77_IMPORTER"))
-                {
-                    symbols.Add("UNIVRM_0_77_IMPORTER");
-                }
-
-                symbols.Remove("UNIVRM_LEGACY_IMPORTER");
-                symbols.Remove("UNIVRM_0_68_IMPORTER");
+                symbols.Add("UNIVRM_0_77_IMPORTER");
             }
 
             // Exporter
+            symbols.Remove("UNIVRM_0_71_EXPORTER");
+            symbols.Remove("UNIVRM_0_75_EXPORTER");
+            symbols.Remove("UNIVRM_0_79_EXPORTER");
+            symbols.Remove("UNIVRM_LEGACY_EXPORTER");
             if (version.Value.major == 0 && version.Value.minor < 71)
             {
-                if (!symbols.Contains("UNIVRM_LEGACY_EXPORTER"))
-                {
-                    symbols.Add("UNIVRM_LEGACY_EXPORTER");
-                }
-
-                symbols.Remove("UNIVRM_0_71_EXPORTER");
+                symbols.Add("UNIVRM_LEGACY_EXPORTER");
+            }
+            else if (version.Value.major == 0 && version.Value.minor < 75)
+            {
+                symbols.Add("UNIVRM_0_71_EXPORTER");
+            }
+            else if (version.Value.major == 0 && version.Value.minor < 79)
+            {
+                symbols.Add("UNIVRM_0_75_EXPORTER");
             }
             else
             {
-                if (!symbols.Contains("UNIVRM_0_71_EXPORTER"))
-                {
-                    symbols.Add("UNIVRM_0_71_EXPORTER");
-                }
-
-                symbols.Remove("UNIVRM_LEGACY_EXPORTER");
+                symbols.Add("UNIVRM_0_79_EXPORTER");
             }
 
             PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, string.Join(";", symbols));

--- a/DVRSDK/Assets/DVRSDK/Examples/AvatarUpload/Scripts/AvatarUploadManager.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/AvatarUpload/Scripts/AvatarUploadManager.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using UniGLTF;
 using UnityEngine;
 using VRM;
-#if UNIVRM_0_71_EXPORTER || UNIVRM_0_75_EXPORTER || UNIVRM_0_79_EXPORTER
+#if UNIVRM_0_71_EXPORTER || UNIVRM_0_79_EXPORTER
 using VRMShaders;
 #endif
 
@@ -109,8 +109,10 @@ namespace DVRSDK.Test
             var gltf = VRMExporter.Export(MeshExportSettings.Default, vrm, _ => false);
             return gltf.ToGlbBytes();
 #elif UNIVRM_0_75_EXPORTER
-            var gltf = VRMExporter.Export(MeshExportSettings.Default, vrm, new RuntimeTextureSerializer());
-            return gltf.ToGlbBytes();
+#error untested because UniVRM Assembly loading issue (0.75~0.78)
+            //var gltf = VRMExporter.Export(MeshExportSettings.Default, vrm, new RuntimeTextureSerializer());
+            //return gltf.ToGlbBytes();
+            throw new System.NotImplementedException("untested because UniVRM Assembly loading issue (0.75~0.78)");
 #elif UNIVRM_0_79_EXPORTER
             var gltf = VRMExporter.Export(new GltfExportSettings(), vrm, new RuntimeTextureSerializer());
             return gltf.ToGlbBytes();

--- a/DVRSDK/Assets/DVRSDK/Examples/AvatarUpload/Scripts/AvatarUploadManager.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/AvatarUpload/Scripts/AvatarUploadManager.cs
@@ -8,6 +8,7 @@ using VRM;
 using VRMShaders;
 #endif
 
+
 namespace DVRSDK.Test
 {
     public class AvatarUploadManager : MonoBehaviour
@@ -108,10 +109,10 @@ namespace DVRSDK.Test
             var gltf = VRMExporter.Export(MeshExportSettings.Default, vrm, _ => false);
             return gltf.ToGlbBytes();
 #elif UNIVRM_0_75_EXPORTER
-            var gltf = VRMExporter.Export(new GltfExportSettings(), vrm, _ => false);
+            var gltf = VRMExporter.Export(MeshExportSettings.Default, vrm, new RuntimeTextureSerializer());
             return gltf.ToGlbBytes();
 #elif UNIVRM_0_79_EXPORTER
-            var gltf = VRMExporter.Export(new GltfExportSettings(), vrm, /* ここを何とかする必要がある */　);
+            var gltf = VRMExporter.Export(new GltfExportSettings(), vrm, new RuntimeTextureSerializer());
             return gltf.ToGlbBytes();
 #else
             return null;

--- a/DVRSDK/Assets/DVRSDK/Examples/AvatarUpload/Scripts/AvatarUploadManager.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/AvatarUpload/Scripts/AvatarUploadManager.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using UniGLTF;
 using UnityEngine;
 using VRM;
-#if UNIVRM_0_71_EXPORTER
+#if UNIVRM_0_71_EXPORTER || UNIVRM_0_75_EXPORTER || UNIVRM_0_79_EXPORTER
 using VRMShaders;
 #endif
 
@@ -106,6 +106,12 @@ namespace DVRSDK.Test
             return gltf.ToGlbBytes();
 #elif UNIVRM_0_71_EXPORTER
             var gltf = VRMExporter.Export(MeshExportSettings.Default, vrm, _ => false);
+            return gltf.ToGlbBytes();
+#elif UNIVRM_0_75_EXPORTER
+            var gltf = VRMExporter.Export(new GltfExportSettings(), vrm, _ => false);
+            return gltf.ToGlbBytes();
+#elif UNIVRM_0_79_EXPORTER
+            var gltf = VRMExporter.Export(new GltfExportSettings(), vrm, /* ここを何とかする必要がある */　);
             return gltf.ToGlbBytes();
 #else
             return null;


### PR DESCRIPTION
# 概要
UniVRM 0.77～のRuntime Load、および、UniVRM 0.79～のRuntime Exportに対応しました。

# 制約事項
なお、UnitVRM 0.75～0.78のRuntime Exportにも対応しようとしましたが、
そもそも当該バージョンのUniVRMのUnity Packageが正常に利用できないので諦めています。

コメントアウトで実装してありますが、アセンブリ参照エラーによりテストできていません。
当該バージョンで実行しようとした場合、#ErrorとNotImplementedExceptionで実行を阻止します。

# 動作確認環境
Windows 10 x64, Unity 2020.3.16f1にて、UniVRM 0.80との組み合わせで、

+ 2DUIExample
+ AvatarUpload

のみ動作を確認しています。

# GlbLowLevelParserの利用について
過去の動作(byte配列からの読み込み)との互換性のため、GlbFileParserではなく、GlbLowLevelParserを使用しています。
GlbLowLevelParserにはファイルパスを渡す必要がありますが、本クラスが返すGltfDataにて以下の記載があるため
string.Emptyとしています。

```cs
        /// <summary>
        /// Source file path.
        /// Maybe empty if source file was on memory.
        /// </summary>
        public string TargetPath { get; }
```
https://github.com/vrm-c/UniVRM/blob/8b645b060d42ebb406a0a5e39349e143370639f0/Assets/UniGLTF/Runtime/UniGLTF/IO/GltfData.cs#L16

# バージョン判断の根拠
## Runtime Import
Runtime Importerの変更については以下のページの記載を参照しました。
https://vrm.dev/en/docs/univrm/programming/runtime_import/

なお、このページに記載のサンプルは間違いがあると思われます。

## Runtime Export
0.78→0.79
https://github.com/vrm-c/UniVRM/commit/6cfdf8142900165f3dc3770b567c4e540819baa4#diff-68601a7bf53ac52b287826051044116302696e0a5e3148d1ecf6388580b1557e

0.74→0.75(未テスト)
https://github.com/vrm-c/UniVRM/commit/f88e8d728675658495d7b03bea7d37d231f331fe#diff-fdea351931d90d1e57fd9ae008ea2e49c5a5359a41fa8f5290c4cd66afdf7c8e

# その他
Editor拡張による定義が行われる前にビルドエラーになり、Edtor拡張が動いてくれない状況がありましたので、#if分岐を増やして回避し、return null;等が増えています。