### PR TITLE
SetupFirstPerson後にDoCalibrationを呼び出すように変更

### DIFF
--- a/DVRSDK/Assets/DVRSDK/Examples/OculusVRExample/Scripts/OculusVRCalibrationAvatarManager.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/OculusVRExample/Scripts/OculusVRCalibrationAvatarManager.cs
@@ -34,8 +34,8 @@ namespace DVRSDK.Test
         private void OnAvatarLoaded(GameObject model)
         {
             CurrentModel = model;
-            DoCalibration();
             dmmVRConnectUI.SetupFirstPerson(FirstPersonCamera);
+            DoCalibration();
             dmmVRConnectUI.ShowVRM();
             dmmVRConnectUI.AddAutoBlink();
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVRCalibrationAvatarManager.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVRCalibrationAvatarManager.cs
@@ -33,8 +33,8 @@ namespace DVRSDK.Test
         private void OnAvatarLoaded(GameObject model)
         {
             CurrentModel = model;
-            DoCalibration();
             dmmVRConnectUI.SetupFirstPerson(FirstPersonCamera);
+            DoCalibration();
             dmmVRConnectUI.ShowVRM();
             dmmVRConnectUI.AddAutoBlink();
         }


### PR DESCRIPTION
DoCalibrationから呼び出されるFinalIKCalibrator.LoadModel(CopyMeshRenderersForShadow)がレイヤーの設定が済んでいことを前提にしているため。