### PR TITLE
OculusのVirtual Desktop対応

### DIFF
--- a/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
+++ b/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
@@ -4,7 +4,8 @@ Shader "DVRSDK/Mirror"
 	{
 		_MainTex("Base (RGB)", 2D) = "white" {}
 		[HideInInspector] _ReflectionTex("", 2D) = "white" {}
-		[HideInInspector] _IsStereo("Stereo Mode", int) = 0
+		//0:NonStereo 1:従来方法 2:VirtualDesktop対応
+		[HideInInspector] _StereoMode("Stereo Mode", int) = 0
 	}
 	SubShader
 	{
@@ -19,7 +20,7 @@ Shader "DVRSDK/Mirror"
 			#include "UnityStandardCore.cginc"
 
 			sampler2D _ReflectionTex;
-			int _IsStereo;
+			int _StereoMode;
 
 			struct v2f
 			{
@@ -49,7 +50,7 @@ Shader "DVRSDK/Mirror"
 				// デスクトップでも左目の処理に入ってしまうため、StermVRMirror.csからStereoの情報を入力
 
 #ifndef UNITY_SINGLE_PASS_STEREO				
-				if (_IsStereo == 1)
+				if (_StereoMode == 1)
 				{
 					if (unity_CameraProjection[0][2] < 0)
 					{
@@ -60,7 +61,7 @@ Shader "DVRSDK/Mirror"
 						o.refl.x = (o.refl.x * 0.5f) + (o.refl.w * 0.5f);
 					}
 				}
-				else if (_IsStereo == 2)
+				else if (_StereoMode == 2)
 				{
 					if (unity_StereoEyeIndex == 0)
 					{
@@ -72,7 +73,6 @@ Shader "DVRSDK/Mirror"
 					}
 				}
 #endif
-
 				return o;
 			}
 

--- a/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
+++ b/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
@@ -4,6 +4,7 @@ Shader "DVRSDK/Mirror"
 	{
 		_MainTex("Base (RGB)", 2D) = "white" {}
 		[HideInInspector] _ReflectionTex("", 2D) = "white" {}
+		_Stereo("Steleo Mode", int) = 0
 	}
 	SubShader
 	{
@@ -18,6 +19,7 @@ Shader "DVRSDK/Mirror"
 			#include "UnityStandardCore.cginc"
 
 			sampler2D _ReflectionTex;
+			int _Stereo;
 
 			struct v2f
 			{
@@ -42,14 +44,22 @@ Shader "DVRSDK/Mirror"
 
 				// シングルパスステレオレンダリングではない時ComputeScreenPosはサイドバイサイド画像から正しい座標を返しません
 				// ProjectionMatrixの水平方向のスキューが0より小であれば左目用で、0より大であれば右目用のレンダリングパスです
-#ifndef UNITY_SINGLE_PASS_STEREO
-				if (unity_CameraProjection[0][2] < 0)
+
+				// 20220419 Reiya1013
+				// OculusのVirtual DesktopだとProjectionMatrixで右目左目を取れないのでunity_StereoEyeIndexで取得するように変更
+				// デスクトップでも左目の処理に入ってしまうため、StermVRMirror.csからSterelの情報を入力
+
+#ifndef UNITY_SINGLE_PASS_STEREO				
+				if (_Stereo == 1)
 				{
-					o.refl.x = (o.refl.x * 0.5f);
-				}
-				else if (unity_CameraProjection[0][2] > 0)
-				{
-					o.refl.x = (o.refl.x * 0.5f) + (o.refl.w * 0.5f);
+					if (unity_StereoEyeIndex == 0)
+					{
+						o.refl.x = (o.refl.x * 0.5f);
+					}
+					else if (unity_StereoEyeIndex == 1)
+					{
+						o.refl.x = (o.refl.x * 0.5f) + (o.refl.w * 0.5f);
+					}
 				}
 #endif
 

--- a/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
+++ b/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
@@ -4,7 +4,7 @@ Shader "DVRSDK/Mirror"
 	{
 		_MainTex("Base (RGB)", 2D) = "white" {}
 		[HideInInspector] _ReflectionTex("", 2D) = "white" {}
-		_Stereo("Steleo Mode", int) = 0
+		[HideInInspector] _IsStereo("Stereo Mode", int) = 0
 	}
 	SubShader
 	{
@@ -19,7 +19,7 @@ Shader "DVRSDK/Mirror"
 			#include "UnityStandardCore.cginc"
 
 			sampler2D _ReflectionTex;
-			int _Stereo;
+			int _IsStereo;
 
 			struct v2f
 			{
@@ -45,12 +45,11 @@ Shader "DVRSDK/Mirror"
 				// シングルパスステレオレンダリングではない時ComputeScreenPosはサイドバイサイド画像から正しい座標を返しません
 				// ProjectionMatrixの水平方向のスキューが0より小であれば左目用で、0より大であれば右目用のレンダリングパスです
 
-				// 20220419 Reiya1013
 				// OculusのVirtual DesktopだとProjectionMatrixで右目左目を取れないのでunity_StereoEyeIndexで取得するように変更
-				// デスクトップでも左目の処理に入ってしまうため、StermVRMirror.csからSterelの情報を入力
+				// デスクトップでも左目の処理に入ってしまうため、StermVRMirror.csからStereoの情報を入力
 
 #ifndef UNITY_SINGLE_PASS_STEREO				
-				if (_Stereo == 1)
+				if (_IsStereo == 1)
 				{
 					if (unity_StereoEyeIndex == 0)
 					{

--- a/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
+++ b/DVRSDK/Assets/DVRSDK/DVRPlugin/Mirror/Shaders/Mirror.shader
@@ -51,6 +51,17 @@ Shader "DVRSDK/Mirror"
 #ifndef UNITY_SINGLE_PASS_STEREO				
 				if (_IsStereo == 1)
 				{
+					if (unity_CameraProjection[0][2] < 0)
+					{
+						o.refl.x = (o.refl.x * 0.5f);
+					}
+					else if (unity_CameraProjection[0][2] > 0)
+					{
+						o.refl.x = (o.refl.x * 0.5f) + (o.refl.w * 0.5f);
+					}
+				}
+				else if (_IsStereo == 2)
+				{
 					if (unity_StereoEyeIndex == 0)
 					{
 						o.refl.x = (o.refl.x * 0.5f);

--- a/DVRSDK/Assets/DVRSDK/Examples/OculusVRExample/Scripts/Oculus Implementation/OculusVRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/OculusVRExample/Scripts/Oculus Implementation/OculusVRMirror.cs
@@ -12,7 +12,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 2);
+                mirrorSetting.propertyBlock.SetInt("_StereoMode", 2);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, Camera.StereoscopicEye.Left, LeftEyeAnchor);
@@ -25,7 +25,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 0);
+                mirrorSetting.propertyBlock.SetInt("_StereoMode", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/OculusVRExample/Scripts/Oculus Implementation/OculusVRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/OculusVRExample/Scripts/Oculus Implementation/OculusVRMirror.cs
@@ -12,6 +12,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 2);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, Camera.StereoscopicEye.Left, LeftEyeAnchor);
@@ -24,6 +25,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
@@ -13,6 +13,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
+                mirrorSetting.propertyBlock.SetInt("_Stereo", 1);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, EVREye.Eye_Left);
@@ -25,6 +26,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
+                mirrorSetting.propertyBlock.SetInt("_Stereo", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
@@ -13,7 +13,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 2);
+                mirrorSetting.propertyBlock.SetInt("_StereoMode", 2);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, EVREye.Eye_Left);
@@ -26,7 +26,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 0);
+                mirrorSetting.propertyBlock.SetInt("_StereoMode", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
@@ -13,7 +13,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
-                mirrorSetting.propertyBlock.SetInt("_Stereo", 1);
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 1);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, EVREye.Eye_Left);
@@ -26,7 +26,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
-                mirrorSetting.propertyBlock.SetInt("_Stereo", 0);
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/SteamVRExample/Scripts/SteamVR Implementation/SteamVRMirror.cs
@@ -13,7 +13,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 1);
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 2);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, EVREye.Eye_Left);

--- a/DVRSDK/Assets/DVRSDK/Examples/UnityXRExample/Scripts/UnityXR Implementation/UnityXRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/UnityXRExample/Scripts/UnityXR Implementation/UnityXRMirror.cs
@@ -10,7 +10,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 1);
+                mirrorSetting.propertyBlock.SetInt("_StereoMode", 1);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, Camera.StereoscopicEye.Left, InputTracking.GetLocalPosition(XRNode.LeftEye), InputTracking.GetLocalRotation(XRNode.LeftEye));
@@ -23,7 +23,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
-                mirrorSetting.propertyBlock.SetInt("_IsStereo", 0);
+                mirrorSetting.propertyBlock.SetInt("_StereoMode", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }

--- a/DVRSDK/Assets/DVRSDK/Examples/UnityXRExample/Scripts/UnityXR Implementation/UnityXRMirror.cs
+++ b/DVRSDK/Assets/DVRSDK/Examples/UnityXRExample/Scripts/UnityXR Implementation/UnityXRMirror.cs
@@ -10,6 +10,7 @@ namespace DVRSDK.Plugins
             // ステレオモード時は左右の目で別のレンダリングが必要
             if (currentCamera.stereoEnabled)
             {
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 1);
                 if (currentCamera.stereoTargetEye == StereoTargetEyeMask.Both || currentCamera.stereoTargetEye == StereoTargetEyeMask.Left)
                 {
                     RenderEyeMirror(mirrorSetting.texture, currentCamera, Camera.StereoscopicEye.Left, InputTracking.GetLocalPosition(XRNode.LeftEye), InputTracking.GetLocalRotation(XRNode.LeftEye));
@@ -22,6 +23,7 @@ namespace DVRSDK.Plugins
             }
             else
             {
+                mirrorSetting.propertyBlock.SetInt("_IsStereo", 0);
                 base.Render(mirrorSetting, currentCamera);
             }
         }


### PR DESCRIPTION
Virtual DesktopやAirLinkでのミラーを修正しました。
テスト済みは以下の通り
[HMD]-[テストシーン]-[RenderingMode]
・[Quest2/Virtual Desktop]-[StermVRCalibration]-[Multi pass]
・[Quest2/Virtual Desktop]-[StermVRCalibration]-[Single pass]
・[Quest2/Virtual Desktop]-[StermVRCalibration]-[Single pass Instanced]
・[Quest2/AirLink-[StermVRCalibration]-[Multi pass]
・[Quest2/AirLink]-[StermVRCalibration]-[Single pass]
・[Quest2/AirLink]-[StermVRCalibration]-[Single pass Instanced]
・[Index]-[StermVRCalibration]-[Multi pass]
・[Index]-[StermVRCalibration]-[Single pass]
・[Index]-[StermVRCalibration]-[Single pass Instanced]

・[Quest2/Virtual Desktop]-[UnityXRCalibration]-[Multi pass]
・[Quest2/Virtual Desktop]-[UnityXRCalibration]-[Single pass]
・[Quest2/Virtual Desktop]-[UnityXR]Calibration-[Single pass Instanced]
・[Quest2/AirLink-[UnityXRCalibration]-[Multi pass]
・[Quest2/AirLink]-[UnityXRCalibration]-[Single pass]
・[Quest2/AirLink]-[UnityXRCalibration]-[Single pass Instanced]

・[Quest2]-[OculusVRExample]-[Multi pass]
・[Quest2]-[OculusVRExample]-[Single pass]

※Quest2ビルドはOculus Integration 20.1が入手できなかったため38.0を使用
　このため、対象環境でのテストは必要と思います。
※[Index]-[UnityXR]の環境ではテストしていません。
